### PR TITLE
Support for Loading Makefile Targets as Scripts

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,6 +81,17 @@ export function activate(context: vscode.ExtensionContext) {
 		if (now - firstUse >= TIME_THRESHOLD) {
 			promptForRating();
 		}
+
+		const makefilePath = path.join(workspaceFolder, 'Makefile');
+		if (workspaceFolder && fs.existsSync(makefilePath)) {
+
+			// File watcher for Makefile
+			const fileWatcher = vscode.workspace.createFileSystemWatcher(makefilePath);
+
+			fileWatcher.onDidChange(() => packageManagerProvider.refresh());
+			fileWatcher.onDidCreate(() => packageManagerProvider.refresh());
+			fileWatcher.onDidDelete(() => packageManagerProvider.refresh());
+		}
 	}
 }
 


### PR DESCRIPTION
This PR adds support for loading custom targets from Makefile in the workspace directory as scripts that can be run from Pub Studio.

![pubstudio-makefile-script-demo](https://github.com/Mastersam07/pub-studio/assets/58946834/42ced9ba-c660-4a0d-bbfa-bf078e6ac6d0)
